### PR TITLE
Version of zeromq lib to run ezmq_zmq2_SUITE

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,6 +2,12 @@
 
 {deps, [
 	{gen_listener_tcp, ".*", {git, "https://github.com/travelping/gen_listener_tcp.git", {branch, "master"}}}
+	
+	%% This is needed to run ezmq_zmq2_SUITE.erl
+	%% The master branch of erlzmq2(ZeroMQ in the 3.x) is not working with ezmq_zmq2_SUITE.erl
+	%% The ezmq_zmq2_SUITE.erl only work with ZeroMQ 2.x
+	%%,{erlzmq, ".*", {git, "https://github.com/zeromq/erlzmq2", {tag, "2.1.11"}}}
+   
        ]}.
 
 {cover_enabled,         true}.


### PR DESCRIPTION
This is to precise the dependency to run ezmq_zmq2_SUITE tests
The master branch of erlzmq2(ZeroMQ in the 3.x) is not working with ezmq_zmq2_SUITE.erl
The ezmq_zmq2_SUITE.erl only work with ZeroMQ 2.x
