### PR TITLE
handle delivery failure in all socket type FSM

### DIFF
--- a/src/ezmq_socket_dealer.erl
+++ b/src/ezmq_socket_dealer.erl
@@ -63,6 +63,8 @@ idle(check, _, _MqSState, _State) ->
 
 idle(do, queue_send, MqSState, State) ->
     {next_state, idle, MqSState, State};
+idle(do, {deliver_send, abort}, MqSState, State) ->
+    {next_state, idle, MqSState, State};
 idle(do, {deliver_send, Transport}, MqSState, State) ->
     MqSState1 = ezmq:lb(Transport, MqSState),
     {next_state, idle, MqSState1, State};

--- a/src/ezmq_socket_pub.erl
+++ b/src/ezmq_socket_pub.erl
@@ -61,6 +61,8 @@ idle(check, _, _MqSState, _State) ->
 
 idle(do, queue_send, MqSState, State) ->
     {next_state, idle, MqSState, State};
+idle(do, {deliver_send, abort}, MqSState, State) ->
+    {next_state, idle, MqSState, State};
 idle(do, {deliver_send, _Transport}, MqSState, State) ->
     {next_state, idle, MqSState, State};
 idle(do, {control, {PeerId, [{normal, <<0:8>>}]}}, MqSState, State) ->

--- a/src/ezmq_socket_rep.erl
+++ b/src/ezmq_socket_rep.erl
@@ -96,6 +96,9 @@ processing(check, {send, _Msg}, _MqSState, #state{last_recv = Transport}) ->
 processing(check, _, _MqSState, _State) ->
     {error, fsm};
 
+processing(do, {deliver_send, abort}, MqSState, State) ->
+    State1 = State#state{last_recv = none},
+    {next_state, idle, MqSState, State1};
 processing(do, {deliver_send, _Transport}, MqSState, State) ->
     State1 = State#state{last_recv = none},
     {next_state, idle, MqSState, State1};


### PR DESCRIPTION
The socket FSM has to handle do({deliver_send, abort}), otherwise
it might overwrite it's list of transport handlers. Make sure all
FSM do.