### PR TITLE
Subscribe to all channels to work with server side filtering

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 %-*-Erlang-*-
 
 {deps, [
-	{lager, ".*", {git, "https://github.com/basho/lager.git", {tag, "2.1.1"}}},
+%	{lager, ".*", {git, "https://github.com/basho/lager.git", {tag, "2.1.1"}}},
 	{gen_listener_tcp, ".*", {git, "https://github.com/travelping/gen_listener_tcp.git", {tag, "0.3.1"}}}
 	
 	%% This is needed to run ezmq_zmq2_SUITE.erl
@@ -15,4 +15,4 @@
 {cover_export_enabled,  false}.
 {cover_print_enabled,   true}.
 
-{erl_opts, [debug_info, {parse_transform, lager_transform}]}.
+{erl_opts, [debug_info]}.

--- a/rebar.config.travis
+++ b/rebar.config.travis
@@ -1,7 +1,7 @@
 %-*-Erlang-*-
 
 {deps, [
-	{lager, ".*", {git, "https://github.com/basho/lager.git", {branch, "master"}}},
+%	{lager, ".*", {git, "https://github.com/basho/lager.git", {branch, "master"}}},
 	{gen_listener_tcp, ".*", {git, "https://github.com/travelping/gen_listener_tcp.git", {branch, "master"}}},
 	{erlzmq, ".*", {git, "https://github.com/zeromq/erlzmq2.git", {branch, "2.x"}}}
        ]}.
@@ -10,4 +10,4 @@
 {cover_export_enabled,  false}.
 {cover_print_enabled,   true}.
 
-{erl_opts, [debug_info, {parse_transform, lager_transform}]}.
+{erl_opts, [debug_info]}.

--- a/src/ezmq.app.src
+++ b/src/ezmq.app.src
@@ -7,7 +7,6 @@
                   kernel,
                   stdlib,
                   sasl,
-                  lager,
                   gen_listener_tcp
                  ]},
   {mod, { ezmq_app, []}},

--- a/src/ezmq.erl
+++ b/src/ezmq.erl
@@ -345,6 +345,13 @@ handle_cast({deliver_accept, Transport, RemoteId}, State) ->
     State1 = transports_activate(Transport, RemoteId, State),
     send_owner_event(RemoteId, accepted, State1),
     lager:debug("DELIVER_ACCPET: ~p", [lager:pr(State1, ?MODULE)]),
+    if(State1#ezmq_socket.type == sub) ->
+          lager:debug("Subscribe transport: ~p, S ~p", [Transport,State]),
+          %TODO: add fitlters to State and subscribe to needed channels only
+          ezmq_link_send({[Transport], [<<1,"">>]}, State1);
+      true ->
+          ok
+    end,
     State2 = send_queue_run(State1),
     {noreply, State2};
 

--- a/src/ezmq_socket_fsm.erl
+++ b/src/ezmq_socket_fsm.erl
@@ -81,17 +81,17 @@ init(Module, Opts, MqSState) ->
 check(Action, MqSState = #ezmq_socket{fsm = Fsm}) ->
     #fsm_state{module = Module, state_name = StateName, state = State} = Fsm,
     R = Module:StateName(check, Action, MqSState, State),
-    lager:debug("ezmq_socket_fsm state: ~w, check: ~w, Result: ~w", [StateName, Action, R]),
+    logger:debug("ezmq_socket_fsm state: ~w, check: ~w, Result: ~w", [StateName, Action, R]),
     R.
 
 do(Action, MqSState = #ezmq_socket{fsm = Fsm}) ->
     #fsm_state{module = Module, state_name = StateName, state = State} = Fsm,
     case Module:StateName(do, Action, MqSState, State) of
         {error, Reason} ->
-            lager:error("socket fsm for ~w exited with ~p, (~p,~p)~n", [Action, Reason, MqSState, State]),
+            logger:error("socket fsm for ~w exited with ~p, (~p,~p)~n", [Action, Reason, MqSState, State]),
             error(Reason);
         {next_state, NextStateName, NextMqSState, NextState} ->
-            lager:debug("ezmq_socket_fsm: state: ~w, Action: ~w, next_state: ~w", [StateName, Action, NextStateName]),
+            logger:debug("ezmq_socket_fsm: state: ~w, Action: ~w, next_state: ~w", [StateName, Action, NextStateName]),
             NewFsm = Fsm#fsm_state{state_name = NextStateName, state = NextState},
             NextMqSState#ezmq_socket{fsm = NewFsm}
     end.
@@ -100,10 +100,10 @@ close(Transport, MqSState = #ezmq_socket{fsm = Fsm}) ->
     #fsm_state{module = Module, state_name = StateName, state = State} = Fsm,
     case Module:close(StateName, Transport, MqSState, State) of
         {error, Reason} ->
-            lager:error("socket fsm for ~w exited with ~p, (~p,~p)~n", [Transport, Reason, MqSState, State]),
+            logger:error("socket fsm for ~w exited with ~p, (~p,~p)~n", [Transport, Reason, MqSState, State]),
             error(Reason);
         {next_state, NextStateName, NextMqSState, NextState} ->
-            lager:debug("ezmq_socket_fsm: state: ~w, Transport: ~w, next_state: ~w", [StateName, Transport, NextStateName]),
+            logger:debug("ezmq_socket_fsm: state: ~w, Transport: ~w, next_state: ~w", [StateName, Transport, NextStateName]),
             NewFsm = Fsm#fsm_state{state_name = NextStateName, state = NextState},
             NextMqSState#ezmq_socket{fsm = NewFsm}
     end.

--- a/src/ezmq_tcp_socket.erl
+++ b/src/ezmq_tcp_socket.erl
@@ -57,7 +57,7 @@ handle_accept(Sock, State = {MqSocket, Version, Type, Identity}) ->
         {ok, Pid} ->
             ezmq_link:accept(MqSocket, Version, Type, Identity, Pid, Sock);
         Other ->
-            lager:warning("failed to handle accept with error ~p", [Other]),
+            logger:warning("failed to handle accept with error ~p", [Other]),
             gen_tcp:close(Sock)
     end,
     {noreply, State}.
@@ -72,7 +72,7 @@ handle_info(_Info, State) ->
     {noreply, State}.
 
 terminate(_Reason, _State) ->
-    lager:debug("ezmq_tcp_socket terminate on ~p", [_Reason]),
+    logger:debug("ezmq_tcp_socket terminate on ~p", [_Reason]),
     ok.
 
 code_change(_OldVsn, State, _Extra) ->

--- a/test/ezmq_SUITE.erl
+++ b/test/ezmq_SUITE.erl
@@ -431,7 +431,7 @@ tcp_opts(Config) ->
 
 init_per_suite(Config) ->
     ok = application:start(sasl),
-    lager:start(),
+    %%lager:start(),
     %% lager:set_loglevel(lager_console_backend, debug),
     ok = application:start(gen_listener_tcp),
     ok = application:start(ezmq),

--- a/test/ezmq_zmq2_SUITE.erl
+++ b/test/ezmq_zmq2_SUITE.erl
@@ -542,7 +542,7 @@ basic_tests_ezmq(Fun, Transport, IP, Port, Type1, Id1, Type2, Id2, Mode, Size) -
 
 init_per_suite(Config) ->
     application:start(sasl),
-    lager:start(),
+    %%lager:start(),
     %% lager:set_loglevel(lager_console_backend, debug),
     application:start(gen_listener_tcp),
     application:start(ezmq),


### PR DESCRIPTION
This patch fix a problem when libzmq acts as publisher and ezmq as subscriber.
Modern libzmq in pubsub mode require client to subscribe on topics, else client get nothing.
